### PR TITLE
Tentatively migrate to GHC 9.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.12
+# version: 0.13.20210621
 #
-# REGENDATA ("0.12",["github","cabal.project"])
+# REGENDATA ("0.13.20210621",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -30,61 +30,102 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.0.20210422
+            compilerKind: ghc
+            compilerVersion: 9.2.0.20210422
+            setup-method: hvr-ppa
+            allow-failure: true
           - compiler: ghc-9.0.1
+            compilerKind: ghc
+            compilerVersion: 9.0.1
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.10.4
+            compilerKind: ghc
+            compilerVersion: 8.10.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.8.4
+            compilerKind: ghc
+            compilerVersion: 8.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.6.5
+            compilerKind: ghc
+            compilerVersion: 8.6.5
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.4.4
+            compilerKind: ghc
+            compilerVersion: 8.4.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.2.2
+            compilerKind: ghc
+            compilerVersion: 8.2.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.0.2
+            compilerKind: ghc
+            compilerVersion: 8.0.2
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.10.3
+            compilerKind: ghc
+            compilerVersion: 7.10.3
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.8.4
+            compilerKind: ghc
+            compilerVersion: 7.8.4
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.6.3
+            compilerKind: ghc
+            compilerVersion: 7.6.3
+            setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-7.4.2
+            compilerKind: ghc
+            compilerVersion: 7.4.2
+            setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false
     steps:
       - name: apt
         run: |
           apt-get update
-          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
+          apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y $CC cabal-install-3.4
+          apt-get install -y "$HCNAME" cabal-install-3.4
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: Set PATH and environment variables
         run: |
           echo "$HOME/.cabal/bin" >> $GITHUB_PATH
-          echo "LANG=C.UTF-8" >> $GITHUB_ENV
-          echo "CABAL_DIR=$HOME/.cabal" >> $GITHUB_ENV
-          echo "CABAL_CONFIG=$HOME/.cabal/config" >> $GITHUB_ENV
-          HCDIR=$(echo "/opt/$CC" | sed 's/-/\//')
-          HCNAME=ghc
-          HC=$HCDIR/bin/$HCNAME
-          echo "HC=$HC" >> $GITHUB_ENV
-          echo "HCPKG=$HCDIR/bin/$HCNAME-pkg" >> $GITHUB_ENV
-          echo "HADDOCK=$HCDIR/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "LANG=C.UTF-8" >> "$GITHUB_ENV"
+          echo "CABAL_DIR=$HOME/.cabal" >> "$GITHUB_ENV"
+          echo "CABAL_CONFIG=$HOME/.cabal/config" >> "$GITHUB_ENV"
+          HCDIR=/opt/$HCKIND/$HCVER
+          HC=$HCDIR/bin/$HCKIND
+          echo "HC=$HC" >> "$GITHUB_ENV"
+          echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
+          echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
+          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> "$GITHUB_ENV"
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
-          echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
-          echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
-          echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "HEADHACKAGE=false" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--$HCNAME --with-compiler=$HC" >> $GITHUB_ENV
-          echo "GHCJSARITH=0" >> $GITHUB_ENV
+          echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
+          echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
+          echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
+          if [ $((HCNUMVER >= 90200)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
+          echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
-          CC: ${{ matrix.compiler }}
+          HCKIND: ${{ matrix.compilerKind }}
+          HCNAME: ${{ matrix.compiler }}
+          HCVER: ${{ matrix.compilerVersion }}
       - name: env
         run: |
           env
@@ -107,6 +148,17 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          if $HEADHACKAGE; then
+          cat >> $CABAL_CONFIG <<EOF
+          repository head.hackage.ghc.haskell.org
+             url: https://ghc.gitlab.haskell.org/head.hackage/
+             secure: True
+             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
+                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
+                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
+             key-threshold: 3
+          EOF
+          fi
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -145,14 +197,75 @@ jobs:
       - name: generate cabal.project
         run: |
           PKGDIR_quickcheck_instances="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/quickcheck-instances-[0-9.]*')"
-          echo "PKGDIR_quickcheck_instances=${PKGDIR_quickcheck_instances}" >> $GITHUB_ENV
+          echo "PKGDIR_quickcheck_instances=${PKGDIR_quickcheck_instances}" >> "$GITHUB_ENV"
+          rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_quickcheck_instances}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package quickcheck-instances" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/time-compat
+            tag:      dc10e814fcbdd85b7dd8da64df7ae954c580a7ed
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/these
+            tag:      1d03307d2b8ca1c03631df7e9d9651b25907ede2
+            subdir:   these
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/assoc
+            tag:      d43d2eccc31a37475898c56e7273f9ebcc182786
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/indexed-traversable
+            tag:      ea22848a529e1225a0590ac3c73ea06a071
+            subdir:   indexed-traversable
+
+          source-repository-package
+            type:     git
+            location: https://github.com/haskellari/splitmix
+            tag:      4606188a437e6f6478fed2a20cadd716589f25ea
+
+          source-repository-package
+            type:     git
+            location: https://github.com/haskell/random
+            tag:      6d8b9b5f09bfd726662035c2a9687c1c23a3ebbc
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/integer-logarithms
+            tag:      7c774f6024151e284b82dc1ad14f5f454978cdd3
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/hashable
+            tag:      1bd4032cf83dab6640352bb9d31e1390e634a0b6
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/data-fix
+            tag:      fb619187db1b6a358dbe1a62c45b07c904da72d3
+
+          source-repository-package
+            type:     git
+            location: https://github.com/haskell/primitive
+            tag:      1704f59d91ef964f83c120af4974251d50c2eb68
+
+          source-repository-package
+            type:     git
+            location: https://github.com/awjchen/vector
+            tag:      fb6f584abff163a361563a98a7760c563f7a6832
+            subdir:   vector
           EOF
+          if $HEADHACKAGE; then
+          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
+          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(quickcheck-instances)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,63 @@ packages: .
 
 -- allow-newer: bytestring
 -- constraints: bytestring ^>=0.11
+
+-- TODO: Remove the below vendored packages when they have migrated to GHC 9.2
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/time-compat
+  tag: dc10e814fcbdd85b7dd8da64df7ae954c580a7ed
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/these
+  tag: 1d03307d2b8ca1c03631df7e9d9651b25907ede2
+  subdir: these
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/assoc
+  tag: d43d2eccc31a37475898c56e7273f9ebcc182786
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/indexed-traversable
+  tag: ea22848a529e1225a0590ac3c73ea06a071
+  subdir: indexed-traversable
+
+source-repository-package
+  type: git
+  location: https://github.com/haskellari/splitmix
+  tag: 4606188a437e6f6478fed2a20cadd716589f25ea
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/random
+  tag: 6d8b9b5f09bfd726662035c2a9687c1c23a3ebbc
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/integer-logarithms
+  tag: 7c774f6024151e284b82dc1ad14f5f454978cdd3
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/hashable
+  tag: 1bd4032cf83dab6640352bb9d31e1390e634a0b6
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/data-fix
+  tag: fb619187db1b6a358dbe1a62c45b07c904da72d3
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/primitive
+  tag: 1704f59d91ef964f83c120af4974251d50c2eb68
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/vector
+  tag: fb6f584abff163a361563a98a7760c563f7a6832
+  subdir: vector

--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -42,6 +42,8 @@ tested-with:
    || ==8.8.4
    || ==8.10.4
    || ==9.0.1
+   || ==9.2.0.20210422
+   -- TODO: replace with || ==9.2.?
 
 source-repository head
   type:     git
@@ -80,7 +82,7 @@ library
   other-modules:    Test.QuickCheck.Instances.CustomPrelude
   hs-source-dirs:   src
   build-depends:
-      base        >=4.5    && <4.16
+      base        >=4.5    && <4.17
     , QuickCheck  >=2.14.1 && <2.14.3
     , splitmix    >=0.0.2  && <0.2
 
@@ -103,7 +105,7 @@ library
     , transformers-compat   >=0.6.5   && <0.7
     , unordered-containers  >=0.2.2.0 && <0.3
     , uuid-types            >=1.0.3   && <1.1
-    , vector                >=0.9     && <0.13
+    , vector                >=0.9     && <0.14
 
   -- version is irrelevant.
   build-depends:    time

--- a/src/Test/QuickCheck/Instances/Semigroup.hs
+++ b/src/Test/QuickCheck/Instances/Semigroup.hs
@@ -111,6 +111,7 @@ instance Function a => Function (Semi.WrappedMonoid a) where
     function = functionMap Semi.unwrapMonoid Semi.WrapMonoid
 
 
+#if !MIN_VERSION_base(4,16,0)
 instance Arbitrary1 Semi.Option where
     liftArbitrary arb = Semi.Option <$> liftArbitrary arb
     liftShrink shr = map Semi.Option . liftShrink shr . Semi.getOption
@@ -124,3 +125,4 @@ instance CoArbitrary a => CoArbitrary (Semi.Option a) where
 
 instance Function a => Function (Semi.Option a) where
     function = functionMap Semi.getOption Semi.Option
+#endif


### PR DESCRIPTION
This commit allows `quickcheck-instances` to build and run on GHC 9.2.0.20210422, including tests and benchmarks.

This commit is not intended to be merged into main. It includes a lot of "extras" that I needed to get it to run. It is only intended to help with migration at a later date, when the final versions of GHC 9.2 and this library's dependencies become available. At that time, I hope someone can save some time by taking the "good parts" of this commit.

Changes:

- Remove the `Semigroup.Option` instances when base >= 4.16