### PR TITLE
remove Option instances for base-4.16.0 (ghc-9.2)

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -79,7 +79,7 @@ library
   other-modules:    Test.QuickCheck.Instances.CustomPrelude
   hs-source-dirs:   src
   build-depends:
-      base        >=4.5    && <4.16
+      base        >=4.5    && <4.17
     , QuickCheck  >=2.14.1 && <2.14.3
     , splitmix    >=0.0.2  && <0.2
 

--- a/src/Test/QuickCheck/Instances/Semigroup.hs
+++ b/src/Test/QuickCheck/Instances/Semigroup.hs
@@ -111,6 +111,7 @@ instance Function a => Function (Semi.WrappedMonoid a) where
     function = functionMap Semi.unwrapMonoid Semi.WrapMonoid
 
 
+#if !MIN_VERSION_base(4,16,0)
 instance Arbitrary1 Semi.Option where
     liftArbitrary arb = Semi.Option <$> liftArbitrary arb
     liftShrink shr = map Semi.Option . liftShrink shr . Semi.getOption
@@ -124,3 +125,4 @@ instance CoArbitrary a => CoArbitrary (Semi.Option a) where
 
 instance Function a => Function (Semi.Option a) where
     function = functionMap Semi.getOption Semi.Option
+#endif


### PR DESCRIPTION
tested with

```
cabal build --allow-newer=base,template-haskell,ghc-prim,ghc-bignum
cabal test --allow-newer=base,template-haskell,ghc-prim,ghc-bignum
```
