### PR TITLE
Set the size parameter to a large value, to generate UUIDs that don't collide

### DIFF
--- a/src/Test/QuickCheck/Instances/UUID.hs
+++ b/src/Test/QuickCheck/Instances/UUID.hs
@@ -8,7 +8,7 @@ import Test.QuickCheck.Instances.CustomPrelude
 
 import Data.Word (Word32)
 
-import Test.QuickCheck
+import Test.QuickCheck as QuickCheck
 
 import qualified Data.UUID.Types as UUID
 
@@ -21,7 +21,7 @@ uuidFromWords (a,b,c,d) = UUID.fromWords a b c d
 
 -- | Uniform distribution.
 instance Arbitrary UUID.UUID where
-    arbitrary = uuidFromWords <$> arbitrary
+    arbitrary = uuidFromWords <$> QuickCheck.resize 10000 arbitrary
     shrink = map uuidFromWords . shrink . UUID.toWords
 
 instance CoArbitrary UUID.UUID where


### PR DESCRIPTION
I ran into issues with the instance for UUID generating colliding UUIDs.
I expected UUIDs to be globally unique, and have a hunch that others might expect the same.

So I decided to upload this patch in case it's relevant.
**Note:** I chose the number 10 000 out of thin air.

Changelog entry:
* Reduce the likelihood of producing colliding UUIDs by hard-coding the size parameter to a big value.