### PR TITLE
QuickCheck dependency bump

### DIFF
--- a/quickcheck-instances.cabal
+++ b/quickcheck-instances.cabal
@@ -1,5 +1,5 @@
 name:               quickcheck-instances
-version:            0.3.30
+version:            0.3.31
 x-revision:         1
 synopsis:           Common quickcheck instances
 description:
@@ -85,7 +85,7 @@ library
   hs-source-dirs:   src
   build-depends:
       base        >=4.5    && <4.20
-    , QuickCheck  >=2.14.1 && <2.14.4
+    , QuickCheck  >=2.15   && <2.15.1
     , splitmix    >=0.0.2  && <0.2
 
   build-depends:


### PR DESCRIPTION
Bump the dependency to the latest version of QuickCheck with tight bounds.

Please let me know if there are any versioning or bounds policies I should be aware of.